### PR TITLE
Fix typo 重い to 想い

### DIFF
--- a/volume1/tex/ja/graphite.tex
+++ b/volume1/tex/ja/graphite.tex
@@ -901,7 +901,7 @@ Graphiteには\code{carbon-relay}というツールも用意されている。
 \end{aosasect1}
 
 %% \begin{aosasect1}{Design Reflections}
-\begin{aosasect1}{設計に関する重い}
+\begin{aosasect1}{設計に関する想い}
 
 %% My experience in working on Graphite has reaffirmed a belief of mine
 %% that scalability has very little to do with low-level performance but


### PR DESCRIPTION
 元のタイトルは `Design Reflections` なので、`設計に関する想い` と修正しました。
